### PR TITLE
Test: Violate QA Auth0 standards

### DIFF
--- a/tenants/qa/tenantA/app-oidc.yml
+++ b/tenants/qa/tenantA/app-oidc.yml
@@ -6,4 +6,4 @@ oidc:
     - "code"
   security:
     require_https: false
-    enforce_pkce: true
+    enforce_pkce: false


### PR DESCRIPTION
- MFA disabled (QA requires enabled)
- Password length 8 (QA requires 12)
- PKCE disabled (QA requires enabled)